### PR TITLE
Replace deprecated event handlers

### DIFF
--- a/docs/docs.js
+++ b/docs/docs.js
@@ -61,7 +61,7 @@ $("#hideButtons").spectrum({
 
 
 var isDisabled = true;
-$("#toggle-disabled").click(function() {
+$("#toggle-disabled").on("click", function() {
     if (isDisabled) {
         $("#disabled").spectrum("enable");
     }
@@ -464,12 +464,12 @@ $("#triggerSet").spectrum({
 // Show the original input to demonstrate the value changing when calling `set`
 $("#triggerSet").show();
 
-$("#btnEnterAColor").click(function() {
+$("#btnEnterAColor").on("click", function() {
     $("#triggerSet").spectrum("set", $("#enterAColor").val());
 });
 
 $("#toggle").spectrum();
-$("#btn-toggle").click(function() {
+$("#btn-toggle").on("click", function() {
     $("#toggle").spectrum("toggle");
     return false;
 });

--- a/example/example.js
+++ b/example/example.js
@@ -61,14 +61,14 @@ $(function() {
         ]
     });
 
-    $("#size").change(function() {
+    $("#size").on("change", function() {
         var size = Math.min(500, Math.max(50, $(this).val()));
         $(".sp-picker-container").width(size);
 
         colorpickerInput.spectrum("reflow");
     });
 
-    $("#huesize").change(function() {
+    $("#huesize").on("change", function() {
         var size = Math.min(80, Math.max(5, $(this).val()));
 
         $(".sp-hue").css("left", (103 - size) + "%");

--- a/index.html
+++ b/index.html
@@ -759,10 +759,10 @@ $("#picker").spectrum({
 });
 
 // Alternatively, they can be added as an event listener:
-$("#picker").on('move.spectrum', function(e, tinycolor) { });
-$("#picker").on('show.spectrum', function(e, tinycolor) { });
-$("#picker").on('hide.spectrum', function(e, tinycolor) { });
-$("#picker").on('beforeShow.spectrum', function(e, tinycolor) { });
+$("#picker").on("move.spectrum", function(e, tinycolor) { });
+$("#picker").on("show.spectrum", function(e, tinycolor) { });
+$("#picker").on("hide.spectrum", function(e, tinycolor) { });
+$("#picker").on("beforeShow.spectrum", function(e, tinycolor) { });
 </pre>
 
         <h3 id="events-change">change</h3>
@@ -965,7 +965,7 @@ $("#picker").spectrum("option", optionName, newOptionValue);
             </div>
 
             <pre class='prettyprint'>
-$("#btn-toggle").click(function() {
+$("#btn-toggle").on("click", function() {
     $("#toggle").spectrum("toggle");
     return false;
 });
@@ -1011,7 +1011,7 @@ $("#triggerSet").spectrum();
 // Show the original input to demonstrate the value changing when calling `set`
 $("#triggerSet").show();
 
-$("#btnEnterAColor").click(function() {
+$("#btnEnterAColor").on("click", function() {
     $("#triggerSet").spectrum("set", $("#enterAColor").val());
 });
 &lt;/script&gt;

--- a/spectrum.js
+++ b/spectrum.js
@@ -321,14 +321,14 @@
             }
 
             // Prevent clicks from bubbling up to document.  This would cause it to be hidden.
-            container.click(stopPropagation);
+            container.on("click", stopPropagation);
 
             // Handle user typed input
             textInput.change(setFromTextInput);
             textInput.on("paste", function () {
                 setTimeout(setFromTextInput, 1);
             });
-            textInput.keydown(function (e) { if (e.keyCode == 13) { setFromTextInput(); } });
+            textInput.on("keydown", function (e) { if (e.keyCode == 13) { setFromTextInput(); } });
 
             cancelButton.text(opts.cancelText);
             cancelButton.on("click.spectrum", function (e) {


### PR DESCRIPTION
Replace the usage of (deprecated) shortcut methods to attach event handlers with calls to "on".